### PR TITLE
Add SASS source maps for debugging and testing purposes.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,7 +50,7 @@ gulp.task('csslint', function(){
 // Task that compiles scss files down to good old css
 gulp.task('pre-process', function(){
     return gulp.src("./sass/mnml.scss")
-        .pipe(sass())
+        .pipe(sass({sourceComments: 'map'}))
         .on('error', swallowError)
         .pipe(prefix())
         .pipe(size({gzip: false, showFiles: true}))


### PR DESCRIPTION
Allow source mappings of SASS files for development purposes.