### PR TITLE
Browsersync - updated gulpfile.js to use best practices

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ var gulp = require('gulp'),
     minifyCSS = require('gulp-minify-css'),
     sass = require('gulp-sass'),
     csslint = require('gulp-csslint'),
-    browserSync = require('browser-sync'),
+    browserSync = require('browser-sync').create('mnml'),
     browserReload = browserSync.reload;
 
 
@@ -61,24 +61,16 @@ gulp.task('pre-process', function(){
         .pipe(size({gzip: false, showFiles: true}))
         .pipe(size({gzip: true, showFiles: true}))
         .pipe(gulp.dest('./css/'))
-        .pipe(browserSync.reload({stream:true}));
+        .pipe(browserSync.stream({match: '**/*.css'}));
 });
 
 // Initialize browser-sync which starts a static server also allows for
 // browsers to reload on filesave
 gulp.task('browser-sync', function() {
-    browserSync({
-        server: {
-            baseDir: "./"
-        }
+    browserSync.init({
+        server: true
     });
 });
-
-// Function to call for reloading browsers
-gulp.task('bs-reload', function () {
-    browserSync.reload();
-});
-
 
 // Allows gulp to not break after a sass error.
 // Spits error out to console
@@ -95,10 +87,9 @@ function swallowError(error) {
  • Reloads browsers when you change html or sass files
 
 */
-gulp.task('default', ['pre-process', 'bs-reload', 'browser-sync'], function(){
+gulp.task('default', ['pre-process', 'browser-sync'], function(){
   gulp.start('pre-process', 'csslint', 'minify-img');
   gulp.watch('sass/*', ['pre-process']);
-  gulp.watch('css/mnml.css', ['bs-reload']);
-  gulp.watch('*.html', ['bs-reload']);
+  gulp.watch('*.html', browserReload);
 });
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "email": "hi@mrmrs.cc"
   },
   "devDependencies": {
-    "browser-sync": "^2.2.1",
+    "browser-sync": "^2.7.1",
     "event-stream": "^3.2.2",
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.1.0",


### PR DESCRIPTION
1. use the `.create()` method for a dedicated instance
2. use `.stream()` in place of `.reload()`
3. remove baseDir from server config. `./` is assumed when `true` given.
4. don't do a hard reload following CSS changes - you're already doing that when you call .stream() following scss file changes.
5. don't use a separate task for reloading following HTML changes
6. force latest version in package.json