### PR TITLE
Fix autoprefixer

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,18 +13,15 @@ var customMedia = require("postcss-custom-media")
 var css = fs.readFileSync("src/mnml.css", "utf8")
 
 // process css
-var output = postcss([autoprefixer])
+postcss([autoprefixer])
   .use(atImport())
   .use(cssvariables())
   .use(conditionals())
   .use(customMedia())
-  .process(css, {
-    from: "./src/mnml.css",
-    to: "./css/mnml.css"
-  })
-  .css
-
-fs.writeFile("css/mnml.css", output, 'utf-8')
+  .process(css)
+  .then(function (result) {
+    fs.writeFile("css/mnml.css", result.css, 'utf-8')
+});
 
 // Using Sqwish for CSS
 new compressor.minify({


### PR DESCRIPTION
Autoprefixer wasn't working out of the box for me. Not sure if others have this issue, but this seems to fix it.

* Update to syntax used at https://github.com/postcss/autoprefixer/blob/master/README.md#javascript
* Also removed extra `from` and `to` parameters.