### PR TITLE
Fix autoprefixer

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,12 @@ var customMedia = require("postcss-custom-media")
 var css = fs.readFileSync("src/mnml.css", "utf8")
 
 // process css
-var output = postcss([autoprefixer])
+var output = postcss()
   .use(atImport())
   .use(cssvariables())
   .use(conditionals())
   .use(customMedia())
+  .use(autoprefixer())
   .process(css, {
     from: "./src/mnml.css",
     to: "./css/mnml.css"


### PR DESCRIPTION
Sorry my last attempt broke everything :persevere: 

I broke this one down to a much simpler fix, and tested on a fresh mnml clone. Easy way to test is with:

```
:fullscreen {
  display: flex;
}
```

Regarding previous PR #24 , turns up the `from` parameter is important for relative paths, even though it is redundant from setting the `css` string by reading the file. However, I didn't see that because I only tested changing `mnml.css`.