### PR TITLE
Update README to remove Gulp and update copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 View the project page at [http://mn-ml.cc](http://mn-ml.cc "MNML - A light-weight responsive html5 boilerplate.")
 
 MNML is a starting point for prototyping responsive HTML5 PostCSS projects.
-Uses gulp to create a dev environment for rapidly prototyping sites.
+Uses PostCSS to create a dev environment for rapidly prototyping sites.
 
 ## Features
 
@@ -82,7 +82,7 @@ mnml/
 
 The MIT License (MIT)
 
-Copyright (c) 2015 @mrmrs
+Copyright (c) 2016 @mrmrs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Removed reference to Gulp, since it's no longer used. Also updated copyright from 2015 to 2016.