### PR TITLE
Update node-minify to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "autoprefixer": "^6.0.3",
     "browser-sync": "^2.9.6",
-    "node-minify": "^1.2.1",
+    "node-minify": "^1.3.7",
     "parallelshell": "^2.0.0",
     "postcss": "^5.0.8",
     "postcss-browser-reporter": "^0.4.0",


### PR DESCRIPTION
Node-minify errors out until you update to latest version.
![screen shot 2016-02-01 at 10 02 17 am](https://cloud.githubusercontent.com/assets/5818296/12720898/068219c4-c8cb-11e5-8fcb-bc2027476037.png)
